### PR TITLE
Update styles.js to remove `backgroundColor`

### DIFF
--- a/src/lib/styles.js
+++ b/src/lib/styles.js
@@ -1,11 +1,9 @@
 export default {
   activeContainer: {
     border: 'none',
-    backgroundColor: '#ffffff',
   },
   inActiveContainer: {
     border: 'none',
-    backgroundColor: '#ffffff',
     outline: 0,
   },
 };


### PR DESCRIPTION
Removed background colour from the default style as it is currently impossible to change the background of the container. 

With `backgroundColor` removed it will just inherit its parent colour.