### PR TITLE
fix: unblock releases and improve pointer accuracy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,13 +9,19 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   build-test:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0
+          persist-credentials: false
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version-file: .nvmrc
@@ -48,8 +54,11 @@ jobs:
 
   browser-test:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version-file: .nvmrc
@@ -66,8 +75,11 @@ jobs:
         node: ['20', '22', '24']
         react: ['18.3.1', '19.2.8']
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: ${{ matrix.node }}
@@ -85,6 +97,7 @@ jobs:
     if: always()
     needs: consumer-matrix
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - name: Require every consumer matrix entry to pass
         run: test "${{ needs.consumer-matrix.result }}" = success
@@ -93,6 +106,7 @@ jobs:
     if: github.event_name == 'push'
     needs: [build-test, browser-test, consumer-test]
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     concurrency:
       group: release-main
       cancel-in-progress: false
@@ -106,7 +120,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0
-          persist-credentials: true
+          persist-credentials: false
       # npm authenticates this workflow through the package's trusted publisher
       # configuration. Do not add registry-url or NODE_AUTH_TOKEN here because
       # either would override OIDC with token authentication.

--- a/commitlint.config.cjs
+++ b/commitlint.config.cjs
@@ -1,6 +1,9 @@
 module.exports = {
   extends: ['@commitlint/config-conventional'],
   rules: {
-    'body-max-line-length': [2, 'always', 120],
+    // GitHub squash merges use the PR body verbatim and do not wrap its lines.
+    // Enforce the conventional header without blocking an otherwise valid
+    // release because a prose body happens to be longer than a terminal line.
+    'body-max-line-length': [0],
   },
 };

--- a/e2e.html
+++ b/e2e.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Rating browser test harness</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/e2e-main.tsx"></script>
+  </body>
+</html>

--- a/e2e/rating.spec.ts
+++ b/e2e/rating.spec.ts
@@ -2,7 +2,7 @@ import AxeBuilder from '@axe-core/playwright';
 import { expect, test } from '@playwright/test';
 
 test.beforeEach(async ({ page }) => {
-  await page.goto('/e2e');
+  await page.goto('/e2e.html');
 });
 
 test('supports the complete slider keyboard model and focus re-entry', async ({
@@ -72,6 +72,20 @@ test('touch selects a half star', async ({ page }) => {
     box!.y + box!.height / 2,
   );
   await expect(page.getByTestId('rating-value')).toHaveText('2.5');
+});
+
+test('uses the rendered width when CSS scales a star', async ({ page }) => {
+  const thirdStar = page
+    .getByRole('slider', { name: 'Scaled rating' })
+    .locator('svg')
+    .nth(2);
+  const box = await thirdStar.boundingBox();
+  expect(box).not.toBeNull();
+
+  // This is left of the rendered midpoint, but right of size / 2 after the
+  // horizontal scale. Comparing with the size prop would incorrectly choose 3.
+  await page.mouse.click(box!.x + box!.width * 0.4, box!.y + box!.height / 2);
+  await expect(page.getByTestId('scaled-rating-value')).toHaveText('2.5');
 });
 
 test('read-only mode wins over isArrowSubmit', async ({ page }) => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -49,7 +49,7 @@
         "publint": "^0.3.24",
         "react": "^19.2.8",
         "react-dom": "^19.2.8",
-        "react-hook-form": "^7.86.0",
+        "react-hook-form": "^7.87.0",
         "rimraf": "^6.1.3",
         "semantic-release": "^25.0.9",
         "size-limit": "^13.0.3",
@@ -13172,9 +13172,9 @@
       "license": "MIT"
     },
     "node_modules/react-hook-form": {
-      "version": "7.86.0",
-      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.86.0.tgz",
-      "integrity": "sha512-4kbWJrh5jPZt1+YqVcXcGKffGcXV/XVbozknLh0Yjh0KhpoAkus21TAQhzRYqNwFkkObmnSvRlZZ3GT+ehoIrA==",
+      "version": "7.87.0",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.87.0.tgz",
+      "integrity": "sha512-zhFzWvLxNHH+8839OnZcUxgMZw88ah2jZWDWvKWgF3Tpbnd0vKL+dlcuU3nZVWESZQjd81EW8K+wU+cYfYAc0w==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -125,7 +125,7 @@
     "publint": "^0.3.24",
     "react": "^19.2.8",
     "react-dom": "^19.2.8",
-    "react-hook-form": "^7.86.0",
+    "react-hook-form": "^7.87.0",
     "rimraf": "^6.1.3",
     "semantic-release": "^25.0.9",
     "size-limit": "^13.0.3",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -19,7 +19,7 @@ export default defineConfig({
   webServer: [
     {
       command: 'npm run dev -- --host 127.0.0.1 --port 4173',
-      url: 'http://127.0.0.1:4173/e2e',
+      url: 'http://127.0.0.1:4173/e2e.html',
       reuseExistingServer: !process.env.CI,
     },
     {

--- a/src/E2EHarness.tsx
+++ b/src/E2EHarness.tsx
@@ -6,6 +6,7 @@ const E2EHarness = () => {
   const [rating, setRating] = useState(1);
   const [changeCount, setChangeCount] = useState(0);
   const [formRating, setFormRating] = useState(2);
+  const [scaledRating, setScaledRating] = useState(1);
   const [submittedRating, setSubmittedRating] = useState<number | null>(null);
 
   const handleRatingChange = (nextValue: number) => {
@@ -31,6 +32,24 @@ const E2EHarness = () => {
       <output data-testid="rating-value">{rating}</output>
       <output data-testid="change-count">{changeCount}</output>
       <button type="button">Next control</button>
+
+      <div
+        style={{
+          transform: 'scaleX(2)',
+          transformOrigin: 'left center',
+          width: 'fit-content',
+        }}
+      >
+        <ReactStarsRating
+          id="scaled-rating"
+          value={scaledRating}
+          onChange={setScaledRating}
+          size={40}
+          isHalf
+          ariaLabel="Scaled rating"
+        />
+      </div>
+      <output data-testid="scaled-rating-value">{scaledRating}</output>
 
       <ReactStarsRating
         id="readonly-rating"

--- a/src/e2e-main.tsx
+++ b/src/e2e-main.tsx
@@ -1,11 +1,11 @@
 import ReactDOM from 'react-dom/client';
 import { StrictMode } from 'react';
 
-import Examples from './examples';
+import E2EHarness from './E2EHarness';
 import './index.css';
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <Examples />
+    <E2EHarness />
   </StrictMode>,
 );

--- a/src/lib/index.tsx
+++ b/src/lib/index.tsx
@@ -157,9 +157,12 @@ const ReactStarsRating = ({
   }, [value]);
 
   const isMoreThanHalf = (event: MouseEvent<SVGSVGElement>) => {
-    const point =
-      event.clientX - event.currentTarget.getBoundingClientRect().left;
-    return point > size / 2;
+    const bounds = event.currentTarget.getBoundingClientRect();
+    const point = event.clientX - bounds.left;
+
+    // Use the rendered width rather than the size prop. This keeps half-star
+    // selection accurate when consumer CSS scales or otherwise resizes an SVG.
+    return point > bounds.width / 2;
   };
 
   const getValueFromEvent = (


### PR DESCRIPTION
## Summary

- make commitlint compatible with GitHub squash-merge bodies so main releases are not blocked by prose wrapping
- use rendered SVG width for accurate half-star selection under CSS scaling
- move the Playwright harness to a dedicated HTML entry so production demo builds exclude test-only code
- add CI concurrency cancellation, job timeouts, and disable persisted checkout credentials
- update react-hook-form to 7.87.0

## Validation

- 48 unit tests with 100% coverage
- 11 Playwright/Storybook accessibility tests
- ESM, CJS, and UMD builds and size budgets
- publint and Are the Types Wrong
- React 18 and React 19 packed-consumer SSR/hydration
- Storybook and production-site builds
- semantic-release note generation
- commitlint against the previously rejected squash commit