### PR TITLE
feat: add a distinct hover preview color

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![CI](https://github.com/fedoryakubovich/react-awesome-stars-rating/actions/workflows/ci.yml/badge.svg)](https://github.com/fedoryakubovich/react-awesome-stars-rating/actions/workflows/ci.yml)
 [![license](https://img.shields.io/npm/l/react-awesome-stars-rating)](https://github.com/fedoryakubovich/react-awesome-stars-rating/blob/main/LICENSE)
 
-An accessible star rating component for React. Half stars from pointer position, full keyboard control, any scale or palette — in about 1.5 kB gzipped with no runtime dependencies.
+An accessible star rating component for React. Half stars from pointer position, full keyboard control, any scale or palette — in under 2 kB gzipped with no runtime dependencies.
 
 **[Live demo](https://react-awesome-stars-rating.vercel.app)** · **[Storybook](https://react-awesome-stars-rating.vercel.app/storybook)**
 
@@ -12,7 +12,7 @@ An accessible star rating component for React. Half stars from pointer position,
 
 ## Highlights
 
-- ~1.5 kB gzipped, no runtime dependencies
+- Under 2 kB gzipped, no runtime dependencies
 - Half-star precision from pointer position, plus arrow-key stepping
 - `role="slider"` with live `aria-valuenow` / `aria-valuetext`, verified with axe-core
 - ESM + CJS with correct types for each, and a UMD bundle for CDN use
@@ -82,6 +82,7 @@ export default function Example() {
 | className      | Container class                           | `string`                  | `''`            |
 | primaryColor   | Active star color                         | `string`                  | `'orange'`      |
 | secondaryColor | Inactive star color                       | `string`                  | `'grey'`        |
+| hoverColor     | Optional pointer-preview color            | `string`                  | `undefined`     |
 | isArrowSubmit  | Arrow keys trigger `onChange` immediately | `boolean`                 | `false`         |
 | ariaLabel      | Accessible label (if no `ariaLabelledBy`) | `string`                  | `'Star rating'` |
 | ariaLabelledBy | ID of element that labels the control     | `string`                  | `undefined`     |
@@ -101,6 +102,26 @@ The control renders as a single `role="slider"` element with `aria-valuemin`, `a
 With `isArrowSubmit`, each arrow step reports through `onChange` immediately rather than waiting for `Enter` or blur.
 
 When `isEdit` is `false` the control is inert regardless of `isArrowSubmit`: no hover preview, no keyboard, `tabIndex={-1}`, and `aria-readonly="true"`.
+
+### Hover preview color
+
+Set `hoverColor` to distinguish the pointer preview from both the saved value
+and inactive stars. It is opt-in, so omitting it preserves the original
+two-color presentation.
+
+```tsx
+<ReactStarsRating
+  value={3}
+  primaryColor="#f59e0b"
+  hoverColor="#38bdf8"
+  secondaryColor="#374151"
+/>
+```
+
+When the pointer previews `1.5`, the first `1.5` stars use `hoverColor`, the
+remainder of the saved value uses `primaryColor`, and inactive stars use
+`secondaryColor`. When previewing above the saved value, only the additional
+preview region uses `hoverColor`.
 
 ## Server components
 

--- a/e2e/rating.spec.ts
+++ b/e2e/rating.spec.ts
@@ -106,11 +106,32 @@ test('integrates with a controlled HTML form', async ({ page }) => {
   await expect(page.getByTestId('submitted-rating')).toHaveText('3');
 });
 
+test('renders saved, hover, and inactive colors in a real browser', async ({
+  page,
+}) => {
+  await page.goto(
+    'http://127.0.0.1:6006/iframe.html?id=components-reactstarsrating--hover-palette&viewMode=story',
+  );
+  const secondStar = page.getByRole('slider').locator('svg').nth(1);
+  const box = await secondStar.boundingBox();
+  expect(box).not.toBeNull();
+
+  await page.mouse.move(box!.x + box!.width * 0.25, box!.y + box!.height / 2);
+
+  const colors = await secondStar
+    .locator('stop')
+    .evaluateAll((stops) =>
+      stops.map((stop) => stop.getAttribute('stop-color')),
+    );
+  expect(colors).toEqual(['#38bdf8', '#38bdf8', '#ff8a3d', '#ff8a3d']);
+});
+
 for (const story of [
   'default',
   'read-only',
   'arrow-submit',
   'custom-palette',
+  'hover-palette',
 ]) {
   test(`Storybook ${story} state is accessible and interactive`, async ({
     page,

--- a/package.json
+++ b/package.json
@@ -139,19 +139,19 @@
     {
       "name": "ESM entry",
       "path": "dist/index.mjs",
-      "limit": "1.6 kB",
+      "limit": "2 kB",
       "gzip": true
     },
     {
       "name": "CJS entry",
       "path": "dist/index.cjs",
-      "limit": "1.65 kB",
+      "limit": "2.05 kB",
       "gzip": true
     },
     {
       "name": "UMD bundle",
       "path": "dist/index.umd.cjs",
-      "limit": "1.75 kB",
+      "limit": "2.15 kB",
       "gzip": true
     }
   ],

--- a/src/__tests__/index.test.tsx
+++ b/src/__tests__/index.test.tsx
@@ -531,4 +531,59 @@ describe('Presentation props', () => {
     expect(colors).toContain('red');
     expect(colors).toContain('blue');
   });
+
+  test('uses three regions when hoverColor previews below the saved value', async () => {
+    const user = userEvent.setup();
+    render(
+      <ReactStarsRating
+        value={3}
+        size={30}
+        primaryColor="orange"
+        hoverColor="cyan"
+        secondaryColor="grey"
+      />,
+    );
+
+    const second = withLayout(getStars()[1], 30);
+    await user.pointer({ target: second, coords: { clientX: 5 } });
+
+    const colorsByStar = getStars().map((star) =>
+      [...star.querySelectorAll('stop')].map((stop) =>
+        stop.getAttribute('stop-color'),
+      ),
+    );
+    expect(colorsByStar[0]).toEqual(['cyan', 'cyan']);
+    expect(colorsByStar[1]).toEqual(['cyan', 'cyan', 'orange', 'orange']);
+    expect(colorsByStar[2]).toEqual(['orange', 'orange']);
+    expect(colorsByStar[3]).toEqual(['grey', 'grey']);
+  });
+
+  test('colors only the additional region when previewing above the value', async () => {
+    const user = userEvent.setup();
+    render(
+      <ReactStarsRating
+        value={1.5}
+        size={30}
+        primaryColor="orange"
+        hoverColor="cyan"
+        secondaryColor="grey"
+      />,
+    );
+
+    const third = withLayout(getStars()[2], 30);
+    await user.pointer({ target: third, coords: { clientX: 25 } });
+
+    const secondColors = [...getStars()[1].querySelectorAll('stop')].map(
+      (stop) => stop.getAttribute('stop-color'),
+    );
+    expect(secondColors).toEqual(['orange', 'orange', 'cyan', 'cyan']);
+    expect(
+      [...getStars()[2].querySelectorAll('stop')].map((stop) =>
+        stop.getAttribute('stop-color'),
+      ),
+    ).toEqual(['cyan', 'cyan']);
+
+    await user.unhover(third);
+    expect(getSlider().querySelectorAll('[id*="-hover-"]')).toHaveLength(0);
+  });
 });

--- a/src/examples/Playground.tsx
+++ b/src/examples/Playground.tsx
@@ -4,11 +4,36 @@ import ReactStarsRating from '../lib';
 import CodeBlock from './CodeBlock';
 
 const PALETTES = [
-  { name: 'Ember', primary: '#ff8a3d', secondary: '#e2e8f0' },
-  { name: 'Gold', primary: '#f5b301', secondary: '#ede9e0' },
-  { name: 'Rose', primary: '#f43f5e', secondary: '#fbe3e8' },
-  { name: 'Ocean', primary: '#0ea5e9', secondary: '#dbeafe' },
-  { name: 'Forest', primary: '#16a34a', secondary: '#dcfce7' },
+  {
+    name: 'Ember',
+    primary: '#ff8a3d',
+    hover: '#38bdf8',
+    secondary: '#e2e8f0',
+  },
+  {
+    name: 'Gold',
+    primary: '#f5b301',
+    hover: '#f97316',
+    secondary: '#ede9e0',
+  },
+  {
+    name: 'Rose',
+    primary: '#f43f5e',
+    hover: '#a855f7',
+    secondary: '#fbe3e8',
+  },
+  {
+    name: 'Ocean',
+    primary: '#0ea5e9',
+    hover: '#22c55e',
+    secondary: '#dbeafe',
+  },
+  {
+    name: 'Forest',
+    primary: '#16a34a',
+    hover: '#eab308',
+    secondary: '#dcfce7',
+  },
 ];
 
 const Playground = () => {
@@ -32,6 +57,7 @@ const Playground = () => {
     `  isEdit={${isEdit}}`,
     isArrowSubmit ? '  isArrowSubmit' : null,
     `  primaryColor="${palette.primary}"`,
+    `  hoverColor="${palette.hover}"`,
     `  secondaryColor="${palette.secondary}"`,
     '/>',
   ]
@@ -65,6 +91,7 @@ const Playground = () => {
             isEdit={isEdit}
             isArrowSubmit={isArrowSubmit}
             primaryColor={palette.primary}
+            hoverColor={palette.hover}
             secondaryColor={palette.secondary}
           />
           <p className="mt-4 text-sm text-slate-600">
@@ -131,7 +158,9 @@ const Playground = () => {
               <span
                 aria-hidden="true"
                 className="size-3 rounded-full"
-                style={{ backgroundColor: item.primary }}
+                style={{
+                  background: `linear-gradient(90deg, ${item.primary} 50%, ${item.hover} 50%)`,
+                }}
               />
               {item.name}
             </button>

--- a/src/lib/ReactStarsRating.stories.tsx
+++ b/src/lib/ReactStarsRating.stories.tsx
@@ -53,6 +53,10 @@ const meta = {
       control: 'color',
       description: 'Inactive star color',
     },
+    hoverColor: {
+      control: 'color',
+      description: 'Optional pointer-preview color',
+    },
     onChange: {
       action: 'onChange',
       description: 'Called when the value changes',
@@ -96,5 +100,12 @@ export const CustomPalette: Story = {
   args: {
     primaryColor: '#22c55e',
     secondaryColor: '#0f172a',
+  },
+};
+
+export const HoverPalette: Story = {
+  args: {
+    value: 3,
+    hoverColor: '#38bdf8',
   },
 };

--- a/src/lib/gradient.tsx
+++ b/src/lib/gradient.tsx
@@ -7,7 +7,14 @@ type GradientProps = {
   fullId: string;
   halfId: string;
   noneId: string;
+  hoverColor?: string;
+  hoverValue?: number | null;
+  committedValue?: number;
+  hoverGradientId?: string;
 };
+
+const asPercent = (value: number, index: number) =>
+  Math.min(100, Math.max(0, Math.round((value - (index - 1)) * 10000) / 100));
 
 const Gradient = ({
   primaryColor,
@@ -18,7 +25,45 @@ const Gradient = ({
   fullId,
   halfId,
   noneId,
+  hoverColor,
+  hoverValue = null,
+  committedValue = value,
+  hoverGradientId,
 }: GradientProps) => {
+  if (hoverColor && hoverValue !== null && hoverGradientId) {
+    const lowerValue = Math.min(committedValue, hoverValue);
+    const upperValue = Math.max(committedValue, hoverValue);
+    const lowerOffset = asPercent(lowerValue, index);
+    const upperOffset = asPercent(upperValue, index);
+    const lowerColor = hoverValue <= committedValue ? hoverColor : primaryColor;
+    const middleColor =
+      hoverValue <= committedValue ? primaryColor : hoverColor;
+    const ranges = [
+      { start: 0, end: lowerOffset, color: lowerColor },
+      { start: lowerOffset, end: upperOffset, color: middleColor },
+      { start: upperOffset, end: 100, color: secondaryColor },
+    ].filter(({ start, end }) => end > start);
+
+    return (
+      <defs>
+        <linearGradient id={hoverGradientId}>
+          {ranges.flatMap(({ start, end, color }, rangeIndex) => [
+            <stop
+              key={`${rangeIndex}-start`}
+              offset={`${start}%`}
+              stopColor={color}
+            />,
+            <stop
+              key={`${rangeIndex}-end`}
+              offset={`${end}%`}
+              stopColor={color}
+            />,
+          ])}
+        </linearGradient>
+      </defs>
+    );
+  }
+
   let computedOffset = offset;
 
   if (index === 1) {

--- a/src/lib/index.tsx
+++ b/src/lib/index.tsx
@@ -86,6 +86,13 @@ export type ReactStarsRatingProps = {
    */
   secondaryColor?: string;
   /**
+   * Optional color for the portion being previewed by the pointer. The saved
+   * value keeps {@link ReactStarsRatingProps.primaryColor}, so moving below an
+   * existing rating can display preview, saved, and inactive regions at once.
+   * When omitted, hover previews retain the original two-color behavior.
+   */
+  hoverColor?: string;
+  /**
    * Report every arrow-key step through
    * {@link ReactStarsRatingProps.onChange} immediately, instead of waiting for
    * `Enter` or blur.
@@ -131,6 +138,7 @@ const ReactStarsRating = ({
   className = '',
   primaryColor = 'orange',
   secondaryColor = 'grey',
+  hoverColor,
   isArrowSubmit = false,
   ariaLabel = 'Star rating',
   ariaLabelledBy,
@@ -142,6 +150,7 @@ const ReactStarsRating = ({
     displayValue: value,
   }));
   const pendingKeyboardValueRef = useRef<number | null>(null);
+  const [hoverValue, setHoverValue] = useState<number | null>(null);
   const displayValue =
     displayState.sourceValue === value ? displayState.displayValue : value;
   const setDisplayValue = (nextValue: number) => {
@@ -181,7 +190,9 @@ const ReactStarsRating = ({
       return;
     }
 
-    setDisplayValue(getValueFromEvent(event, index));
+    const nextValue = getValueFromEvent(event, index);
+    setHoverValue(nextValue);
+    setDisplayValue(nextValue);
   };
 
   const handleMouseLeave = () => {
@@ -189,6 +200,7 @@ const ReactStarsRating = ({
       return;
     }
 
+    setHoverValue(null);
     setDisplayValue(value || 0);
   };
 
@@ -287,6 +299,9 @@ const ReactStarsRating = ({
             noneId={noneId}
             primaryColor={primaryColor}
             secondaryColor={secondaryColor}
+            hoverColor={hoverColor}
+            hoverValue={hoverValue}
+            committedValue={value}
             onMouseMove={(event) => handleMouseMove(event, index)}
             onMouseLeave={handleMouseLeave}
             onChange={(event) => handleChange(event, index)}

--- a/src/lib/star.tsx
+++ b/src/lib/star.tsx
@@ -7,6 +7,9 @@ type StarProps = {
   size: number;
   primaryColor: string;
   secondaryColor: string;
+  hoverColor?: string;
+  hoverValue?: number | null;
+  committedValue?: number;
   onMouseLeave?: (event: MouseEvent<SVGSVGElement>) => void;
   onMouseMove?: (event: MouseEvent<SVGSVGElement>) => void;
   onChange?: (event: MouseEvent<SVGSVGElement>) => void;
@@ -31,6 +34,9 @@ const StarSVG = ({
   isHalf,
   primaryColor,
   secondaryColor,
+  hoverColor,
+  hoverValue = null,
+  committedValue = value,
   fill,
   offset = 50,
   fullId,
@@ -38,8 +44,11 @@ const StarSVG = ({
   noneId,
 }: StarProps) => {
   let computedFill = fill;
+  const hoverGradientId = `${fullId}-hover-${index}`;
 
-  if (index <= value) {
+  if (hoverColor && hoverValue !== null) {
+    computedFill = `url(#${hoverGradientId})`;
+  } else if (index <= value) {
     computedFill = `url(#${fullId})`;
   } else if (isHalf && Math.ceil(value) === index) {
     computedFill = `url(#${halfId})`;
@@ -66,6 +75,10 @@ const StarSVG = ({
         fullId={fullId}
         halfId={halfId}
         noneId={noneId}
+        hoverColor={hoverColor}
+        hoverValue={hoverValue}
+        committedValue={committedValue}
+        hoverGradientId={hoverGradientId}
       />
       <polygon
         fill={computedFill}


### PR DESCRIPTION
## Summary

- add an opt-in `hoverColor` prop while preserving the existing two-color default
- render saved, pointer-preview, and inactive regions independently, including fractional boundaries
- document the API and expose it in the live playground and Storybook
- add unit, real-browser, and accessibility coverage
- update bundle budgets to reflect the feature: 1.86 kB ESM, 1.91 kB CJS, and 1.99 kB UMD gzipped

## Validation

- 50 unit tests with 100% statements, branches, functions, and lines
- 13 Playwright and Storybook accessibility tests
- ESM, CJS, UMD, declaration, package-content, publint, and type-resolution checks
- packed React 18 and React 19 SSR/hydration consumers
- Storybook, production site, size budgets, and semantic-release note generation

Closes #22