### PR TITLE
fix: reset controlled previews and improve consumer guidance

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -79,6 +79,18 @@ updates:
           - react-hook-form
           - '@tanstack/react-form'
 
+  - package-ecosystem: npm
+    directory: /fixtures/next-consumer
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 2
+    commit-message:
+      prefix: test
+      include: scope
+    groups:
+      next-consumer:
+        patterns: ['*']
+
   - package-ecosystem: github-actions
     directory: /
     schedule:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
         with:
           node-version-file: .nvmrc
           cache: npm
-      - run: npm ci
+      - run: node scripts/ci-install.mjs
       - run: npm run format
       - run: npm run lint
       - run: npm run verify:lint
@@ -63,9 +63,14 @@ jobs:
         with:
           node-version-file: .nvmrc
           cache: npm
-      - run: npm ci
+          cache-dependency-path: |
+            package-lock.json
+            fixtures/next-consumer/package-lock.json
+      - run: node scripts/ci-install.mjs
       - run: npx playwright install --with-deps chromium firefox webkit
       - run: npm run test:e2e
+      - name: Verify installed Next.js App Router consumer
+        run: npm run test:next
       - name: Preserve browser failure diagnostics
         if: failure()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -138,7 +143,7 @@ jobs:
         with:
           node-version-file: .nvmrc
           cache: npm
-      - run: npm ci
+      - run: node scripts/ci-install.mjs
       - run: npm run build
       - name: Release
         run: npm run release

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -91,6 +91,7 @@
     {
       "files": [
         "src/**/*.{ts,tsx}",
+        "fixtures/next-consumer/app/**/*.jsx",
         "e2e/**/*.ts",
         "e2e-deployed/**/*.ts",
         "*.config.ts",

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,7 +53,30 @@ conventional-changelog-writer@9 or newer` during `generateNotes`.
 
 Upgrade it only once semantic-release moves to writer 9.
 
-## Pre-commit
+## Consumer and accessibility validation
+
+`npm run test:next` packs the library, installs it into a temporary Next.js
+App Router project, builds for production and checks server rendering and
+hydrated keyboard/clear interactions in Chromium. Run
+`npx playwright install chromium` first. Its isolated dependency lockfile lives
+in `fixtures/next-consumer`; Next.js is not a library dependency. This check is
+part of browser CI and therefore gates release publication.
+
+Physical-device screen-reader testing is tracked separately in
+[the manual checklist](docs/accessibility-testing.md). It is not yet verified;
+automated checks must not be presented as a VoiceOver/TalkBack certification.
+
+### CI installation measurements
+
+The v1.4.0 release run had npm cache hits, but installation took 76s in the
+browser job, 103s in the build job and 272s in the release job. These timings
+alone do not establish whether downloads, audit requests or extraction caused
+the variance. `scripts/ci-install.mjs` reports timings in job summaries and
+uses `--prefer-offline` to favor cached tarballs. Audit, lifecycle scripts,
+clean installs and separate consumer tests remain enabled. Compare several
+runs before claiming a speedup or making further cache changes.
+
+## Commit hooks
 
 - **lint-staged** — Oxfmt and Oxlint run on staged files before each commit.
 - **commitlint** — Commit messages must follow [Conventional Commits](https://www.conventionalcommits.org/) (e.g. `feat: ...`, `fix: ...`, `docs: ...`).

--- a/README.md
+++ b/README.md
@@ -56,16 +56,59 @@ expose React as a global, and expects `window.React` to be present.
 ## Usage
 
 ```tsx
+import { useState } from 'react';
 import ReactStarsRating from 'react-awesome-stars-rating';
 
-const onChange = (value: number) => {
-  console.log(`Rating: ${value}`);
-};
-
 export default function Example() {
-  return <ReactStarsRating onChange={onChange} value={3.5} />;
+  const [rating, setRating] = useState(3.5);
+  return <ReactStarsRating value={rating} onChange={setRating} />;
 }
 ```
+
+Use `value` with a state-updating `onChange` when your application owns the
+rating. For a self-managed input, use `<ReactStarsRating defaultValue={3.5} />`.
+Do not switch between controlled and uncontrolled usage during an input's lifetime.
+
+### Clear a rating
+
+Keep zero as the empty rating and provide an explicitly labeled button:
+
+```tsx
+const [rating, setRating] = useState(0);
+
+<>
+  <ReactStarsRating
+    value={rating}
+    onChange={setRating}
+    ariaLabel="Your rating"
+  />
+  <button type="button" onClick={() => setRating(0)}>
+    Clear rating
+  </button>
+</>;
+```
+
+### Display an average
+
+Use `readOnly` for aggregate scores, with visible text so the number and review
+count are available without interpreting the star graphic:
+
+```tsx
+<>
+  <ReactStarsRating value={4.3} readOnly ariaLabel="Average rating" />
+  <span>4.3 out of 5 · 128 reviews</span>
+</>
+```
+
+With `isHalf`, the SVG displays partial fill for fractional values; editing
+still selects half-star steps. Do not round an average just to display it.
+
+### Next.js App Router
+
+The published entry point includes `"use client"`. A Server Component can render
+a read-only rating with serializable props. Put state and callbacks inside your
+own Client Component (`"use client"` at the top of its file), as in the usage
+example above; do not pass ordinary callback functions from a Server Component.
 
 ## Props
 
@@ -214,6 +257,47 @@ HTML hidden inputs do not participate in native constraint validation, so a
 `required` attribute would be misleading and is intentionally not exposed.
 For required ratings, validate the controlled value or submitted `FormData`
 and expose the result with `aria-invalid` and descriptive error text.
+
+For example, inside a component, validate on submit and focus the rating when
+invalid (also validate submitted data on your server):
+
+```tsx
+const [rating, setRating] = useState(0);
+const [error, setError] = useState(false);
+const ratingRef = useRef<HTMLSpanElement>(null);
+const errorId = useId();
+
+<form
+  onSubmit={(event) => {
+    event.preventDefault();
+    const invalid = rating === 0;
+    setError(invalid);
+    if (invalid) ratingRef.current?.focus();
+    else console.log('Submit rating:', rating);
+  }}
+>
+  <ReactStarsRating
+    ref={ratingRef}
+    name="rating"
+    value={rating}
+    onChange={(value) => {
+      setRating(value);
+      setError(false);
+    }}
+    ariaLabel="Your rating (required)"
+    aria-invalid={error || undefined}
+    aria-describedby={error ? errorId : undefined}
+  />
+  {error && (
+    <p id={errorId} role="alert">
+      Choose a rating before submitting.
+    </p>
+  )}
+  <button type="submit">Submit</button>
+</form>;
+```
+
+Import `useState`, `useRef` and `useId` from React for this recipe.
 
 ### React Hook Form
 

--- a/docs/accessibility-testing.md
+++ b/docs/accessibility-testing.md
@@ -1,0 +1,30 @@
+# Manual assistive-technology checks
+
+Status: **not yet performed on physical devices** for this release. Automated
+axe, keyboard, touch-emulation and hydration tests are not a substitute.
+
+Use the deployed demo and Storybook linked in the README. Test Safari with
+VoiceOver on an iPhone and Chrome with TalkBack on an Android device. Record
+device, OS, browser, assistive-technology version, package version and date.
+
+For each platform:
+
+- Navigate to the rating without sight; confirm its name, slider role, value
+  and range are announced meaningfully.
+- Use the screen reader's adjustment gestures to increase/decrease; verify
+  half-star and whole-star values, zero and maximum, and announcements.
+- Leave the control and return; confirm it remains reachable and changes
+  commit exactly once. Repeat with immediate keyboard submission enabled.
+- Verify read-only average ratings are readable without suggesting they can
+  be edited, and disabled controls cannot change or submit their value.
+- Check Arabic RTL and localized value text, including direction of changes.
+- Submit a required-rating example with zero: hear the error, find the focused
+  rating, correct it, and submit. Clear/reset and verify the submitted value.
+- Test at larger text/display sizes and confirm the page still scrolls.
+
+Record each case as pass, fail or not tested, with exact reproduction steps.
+Do not infer a pass from the visual display or automated accessibility score.
+Report failures as issues with device details; do not include personal data.
+
+WAI explicitly recommends testing sliders with touch-based assistive technology:
+[Slider pattern guidance](https://www.w3.org/WAI/ARIA/apg/patterns/slider/).

--- a/fixtures/next-consumer/app/icon.svg
+++ b/fixtures/next-consumer/app/icon.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16"><path fill="orange" d="m8 1 2 4 5 1-4 4 1 5-4-2-4 2 1-5-4-4 5-1z"/></svg>

--- a/fixtures/next-consumer/app/layout.jsx
+++ b/fixtures/next-consumer/app/layout.jsx
@@ -1,0 +1,7 @@
+export default function RootLayout({ children }) {
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  );
+}

--- a/fixtures/next-consumer/app/page.jsx
+++ b/fixtures/next-consumer/app/page.jsx
@@ -1,0 +1,13 @@
+import ReactStarsRating from 'react-awesome-stars-rating';
+import RatingForm from './rating-form';
+
+// No client directive here: the package must preserve its own client boundary.
+export default function Page() {
+  return (
+    <main>
+      <h1>Installed Next.js consumer</h1>
+      <ReactStarsRating value={4.3} readOnly ariaLabel="Average rating" />
+      <RatingForm />
+    </main>
+  );
+}

--- a/fixtures/next-consumer/app/rating-form.jsx
+++ b/fixtures/next-consumer/app/rating-form.jsx
@@ -1,0 +1,24 @@
+'use client';
+
+import { useState } from 'react';
+import ReactStarsRating from 'react-awesome-stars-rating';
+
+export default function RatingForm() {
+  const [rating, setRating] = useState(3.5);
+  return (
+    <>
+      <ReactStarsRating
+        value={rating}
+        onChange={setRating}
+        ariaLabel="Your rating"
+      />
+      <output data-testid="rating-value">{rating}</output>
+      <button type="button" onClick={() => setRating(0)}>
+        Clear rating
+      </button>
+      <button type="button" onClick={() => setRating(3.5)}>
+        Restore initial rating
+      </button>
+    </>
+  );
+}

--- a/fixtures/next-consumer/package-lock.json
+++ b/fixtures/next-consumer/package-lock.json
@@ -1,0 +1,952 @@
+{
+  "name": "stars-next-consumer-fixture",
+  "version": "0.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "stars-next-consumer-fixture",
+      "version": "0.0.0",
+      "dependencies": {
+        "next": "16.3.4",
+        "react": "19.2.8",
+        "react-dom": "19.2.8"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.3.tgz",
+      "integrity": "sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@img/colour": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
+      "integrity": "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@img/sharp-darwin-arm64": {
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.35.4.tgz",
+      "integrity": "sha512-Uhfl4V4lhP2nbUVF9+hyH1+luj86f1gUFeo8ALYxFoULoU+G87D43BfeMP8XHsk9boxAnCY/bf2EHwhA7MuGsA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-arm64": "1.3.3"
+      }
+    },
+    "node_modules/@img/sharp-darwin-x64": {
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.35.4.tgz",
+      "integrity": "sha512-hWniXY3bG5qKpkKrAwPe4y+VTPmf086YQAnkxWh7uA1YrlRouWGa0M0Mxj3ZjnXFkv7/TD1bTy9lGUK26vRvWw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-x64": "1.3.3"
+      }
+    },
+    "node_modules/@img/sharp-freebsd-wasm32": {
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-freebsd-wasm32/-/sharp-freebsd-wasm32-0.35.4.tgz",
+      "integrity": "sha512-lIsKw/BU+kjB4eZjxrYrZmwOJYi3Ajrv66iAlBmUPyKc3HpnloevB1g3wxGD9P/5BbQ1brBGl65VRRrCvQDEqA==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "dependencies": {
+        "@img/sharp-wasm32": "0.35.4"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-arm64": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.3.3.tgz",
+      "integrity": "sha512-suTBPTDGrI9WodccaDdwZItTSaBYASlBk1NSfElSHrUfzu3szG6lvIF58+WiFvnfzuK8ZBFS5zE00PxqxnRiPg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-x64": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.3.3.tgz",
+      "integrity": "sha512-FVJZ5mITMobmXIz/hPDTw0EintTW5H3WfrxwLqEqjiIihlu+hVRyGrFQ60xl0Lxn7Bt3zdpevPaQi0HEzqz9fw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.3.3.tgz",
+      "integrity": "sha512-3rbU4vqXXc3hY/OiXdl52xZvT0F1yEngWfvqudtPJg/KkyiaQw2DRsFrNzpmLvfavbwOq3qXn36GP8obHRULQA==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm64": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.3.3.tgz",
+      "integrity": "sha512-0DaL0A6Xu6sQSQFwe4iVCrKWU2cCTItnRsYsCdxAMm9NF6twAA9BKnoqy4hqz4+azQ0JHuA26qiUKsf1XJ/v5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-ppc64": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.3.3.tgz",
+      "integrity": "sha512-cdn1OvUBwsXhbC0zSzJnNzf5MZ/mTrobawDvNXBTxe8VtqKAm0sRuEY2Evzovb/w9JMk4TvRxqt1mekSuJz64w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-riscv64": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.3.3.tgz",
+      "integrity": "sha512-HjPVx7yKz+0lqdhDlTw1tt90wamBoxhiXpvl1XZpJLiHH4RCJ5yDTqH+VlYPv2fwFs89JFw4c1IexYOcQUi4IQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-s390x": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.3.3.tgz",
+      "integrity": "sha512-neWLh+3yCNThxnfy3c4BbVBeGgt9aftno+XbT56iK28RgeDs3UOFWviLWlUu0bArYVYJaFDK+RRohbicUNCm8Q==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-x64": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.3.3.tgz",
+      "integrity": "sha512-4vKmvAst9nrowcqquKFAyZJUDolUaIp8uRiN0mWFguJ1IplC9/pitXtlnnlU4aa/eJw3J7i67V+pwUL+wZGdsA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.3.3.tgz",
+      "integrity": "sha512-Y9kQaLMuNoB0bPYOOdcZMaseNrFpPodIWWMrx+CZyydf2xn68j9WYc6sWWRrDwNkzCQjKYfc68L7jKjGlHMibw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-x64": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.3.3.tgz",
+      "integrity": "sha512-fj8Mv0HHfD1Rr+4I68+3agJynxDWtBFgicTbSOb9Bke6pIwzGcJ+RX/yHjmiEGFMCavY/dxvem7MyNaJF+wDiw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm": {
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.35.4.tgz",
+      "integrity": "sha512-7OAS8gI0EReKGVN2HssHlM6umJgxF5VI3xN0p9FA91p/YO+ou5hiNghLdZ5BEHztwaaK5+bLKRf8x/o2L2nk9A==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm": "1.3.3"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm64": {
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.35.4.tgz",
+      "integrity": "sha512-De4jpEnAU8Hd5oT0j1G3uL4ZvTuipVMn7YC6vPaJhy6/7EwEae0SVAoBrUMYQbkLGDm85taVWwuPc1a44LTzCQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm64": "1.3.3"
+      }
+    },
+    "node_modules/@img/sharp-linux-ppc64": {
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.35.4.tgz",
+      "integrity": "sha512-2oYZJeIl4kCcMGk4ouZVjnkCtFrpQFlNEtJ6GbxzhHQchwH0NH/qEb9ykmOl29dqwMq+JhFdZn+1ak2FKhI9fQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-ppc64": "1.3.3"
+      }
+    },
+    "node_modules/@img/sharp-linux-riscv64": {
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.35.4.tgz",
+      "integrity": "sha512-cPbNChoRURAWdebDIHSenxRpgEdy7JkPydSnUxRm9VvKD7m0/xVaR/8Fzlu81pk5nHEvHH87UZUA7cTtwnbJSA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-riscv64": "1.3.3"
+      }
+    },
+    "node_modules/@img/sharp-linux-s390x": {
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.35.4.tgz",
+      "integrity": "sha512-RY0JFY8Fd6RonCBtHz+DvadaPkXDSI1AUn6yWL9TipqkZ1vY8w8evqdgyDFnkm4/K1ve1TvZiaePP5oSd4+WVQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-s390x": "1.3.3"
+      }
+    },
+    "node_modules/@img/sharp-linux-x64": {
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.35.4.tgz",
+      "integrity": "sha512-9qvvEAuk8k89TfWUoX2htWjbAMX8p+NxCppjpcg5k6xMsjhBQPTsoIh36h9Qde4WRuGpJeYnOjdosDn/cnv+OA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-x64": "1.3.3"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-arm64": {
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.35.4.tgz",
+      "integrity": "sha512-KB5jxpfWQTr0nc3xdHtWChdbifHrBGsd2SM62Eyxrl8afikm+f5qGBU75SJIZBT/S1MC8XyacdlXBMSWq6OURA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-arm64": "1.3.3"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-x64": {
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.35.4.tgz",
+      "integrity": "sha512-f+eZJZIQNEEd26RPSW+76chwOf1XtA2Y/O+5ocVyLliHkeih3e+jhLVBdNTd2rS3IbNXK8+ug93Vf5ZXtF5Lxg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-x64": "1.3.3"
+      }
+    },
+    "node_modules/@img/sharp-wasm32": {
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.35.4.tgz",
+      "integrity": "sha512-zQnl4Kwp7Q6NHsENtU2T/00Zi+w3AQNwz3+UaTyVBy2FpXrzXzGjndpK61onhZjRtRpQXxCTeqw19bVyXOh7jA==",
+      "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/runtime": "^1.11.3"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-webcontainers-wasm32": {
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-webcontainers-wasm32/-/sharp-webcontainers-wasm32-0.35.4.tgz",
+      "integrity": "sha512-ESfNkywmCfPNyaZjxooddJQiQ+l/nTpGEOGthxiLnIHXC/CmcBixnfwUleX9mCz9ovrUUvKMap/pm8RYbzfwaA==",
+      "cpu": [
+        "wasm32"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@img/sharp-wasm32": "0.35.4"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-arm64": {
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.35.4.tgz",
+      "integrity": "sha512-iNdlBX9gLVvqe2I3uIJSIKTq6wckP/DYxZtcqxm09x5Gi24DnFBmPAWZmr60ZyYMG0xlzo6goG3670ar+RXvRw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-ia32": {
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.35.4.tgz",
+      "integrity": "sha512-kqRsbaa5CS6KHlpxnN7WhE6vAAugXyZButpRdvDWetlv6Qv4N9WTcrWzF7tXfB9T7MsoadqdI8hmwLq6UlLvtw==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-x64": {
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.35.4.tgz",
+      "integrity": "sha512-XtmnYhBcrORsJ4XJngyzr/EWP0hRZLAZRFaApdKuviyqF78+ylxh2y06ZmtULAMOnObJ3ucpN0AcwSWnMowTRg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@next/env": {
+      "version": "16.3.4",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-16.3.4.tgz",
+      "integrity": "sha512-cjWZnUUa6jZq2kFaNe/ZyJdZonOZ/QoN0Zka2nz/FLOrfx14pQuM9c5RaSVkWMqgdt4ksgPAMWPyHSs/CyV48Q==",
+      "license": "MIT"
+    },
+    "node_modules/@next/swc-darwin-arm64": {
+      "version": "16.3.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.3.4.tgz",
+      "integrity": "sha512-iBr3I5LZNk5/bgl5//iTgD2tcym14MX0Xo7fD//u9dYAEgGzza1y9oywluPtf74YnOswVdH1908aK9xVz7zQTw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-darwin-x64": {
+      "version": "16.3.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.3.4.tgz",
+      "integrity": "sha512-2dpiSyl2Jw/NrBPaU2MAKGSa+2MR82pJIn4Sm5Rjr+gxAeuh0z158Su3Z2O8zn7UNNq+ej4bToed6RcRN/Lydg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-gnu": {
+      "version": "16.3.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.3.4.tgz",
+      "integrity": "sha512-+t+U8HZT+fApePCS5h89CSH3datz29MkzyfCn+6fpsZBG/oiEOhINcb9rtkv6sdpToLGFn2e6146NzaKCXkqrA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-musl": {
+      "version": "16.3.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.3.4.tgz",
+      "integrity": "sha512-mx03GNs1ocQA5JQ4FxDMmIsNkdrZh8cuezKCrId28e5/gIPU/l7Kcy2+vmCCzdjnnmXJy+iOAu+7K0QppO6Urg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-x64-gnu": {
+      "version": "16.3.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.3.4.tgz",
+      "integrity": "sha512-YIhGY6fSMfha52bnVxnzc9zaVBzJg+cqQTOD8tXIBSx4fuv0pVMxQTE0PaS59YhnMOiYiG09IMwxJAf/CFm/Dw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-x64-musl": {
+      "version": "16.3.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.3.4.tgz",
+      "integrity": "sha512-+eaaX6axpDb0yF1GCpiERe6njplvdC+nks/fKfcHu3XPGRrald8P3/X7yv7QLdjA51knnxwl9pxdIJsg+w1L+Q==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-arm64-msvc": {
+      "version": "16.3.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.3.4.tgz",
+      "integrity": "sha512-0jcXW7Xs/uzICrmgV3MhDYDeRy++1CqnpDIerlPIqYO4bhzB4WNbX/aRnQclustsAyTkFKB0z6rbcjmNg5tR8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-x64-msvc": {
+      "version": "16.3.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.3.4.tgz",
+      "integrity": "sha512-vvBzwu1pYQCp92maZCFCIw/XgOTMR5tur9GjakwIo2cmwRTMKajRZZDS9+e4KsUZWKu1E007WUeAFXRRjZeuzw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@swc/helpers": {
+      "version": "0.5.23",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.23.tgz",
+      "integrity": "sha512-5lSsMOTXURePglDfvuAQUqkGek9Hg2kksOYay2m0+XR++b2NWYL/4sWyuvVBIs8oKnJaxkdi9whaL/sqN13afw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.11.21",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.21.tgz",
+      "integrity": "sha512-uh8vpY/1/YyFkunIDFH/12p7/7VdPKA1hejMVEbdkEaWnUz0Hesvx5EbiU6XxjyHZIOju+ZMbQJkRh+es3/spQ==",
+      "license": "Apache-2.0",
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001810",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001810.tgz",
+      "integrity": "sha512-TITQPUkaz+aVk5GL6NhOdwk1aEaNTSDPsGFWrTuhKGtjTF70jL/Oht2W4c6rXUe5fu7Ie19VIahAXHIIiWWNeg==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "CC-BY-4.0"
+    },
+    "node_modules/client-only": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
+      "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==",
+      "license": "MIT"
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/next": {
+      "version": "16.3.4",
+      "resolved": "https://registry.npmjs.org/next/-/next-16.3.4.tgz",
+      "integrity": "sha512-/Ztf6CeRH+ejEXUrYtqI4gkS66eFIHuSwqi60RgcpWKodxFZx2/dqVCMKBwILfAHXQ+F1b1vAudgj3mnxqtoIA==",
+      "license": "MIT",
+      "dependencies": {
+        "@next/env": "16.3.4",
+        "@swc/helpers": "0.5.23",
+        "baseline-browser-mapping": "^2.9.19",
+        "caniuse-lite": "^1.0.30001579",
+        "postcss": "8.5.23",
+        "styled-jsx": "5.1.6"
+      },
+      "bin": {
+        "next": "dist/bin/next"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "optionalDependencies": {
+        "@next/swc-darwin-arm64": "16.3.4",
+        "@next/swc-darwin-x64": "16.3.4",
+        "@next/swc-linux-arm64-gnu": "16.3.4",
+        "@next/swc-linux-arm64-musl": "16.3.4",
+        "@next/swc-linux-x64-gnu": "16.3.4",
+        "@next/swc-linux-x64-musl": "16.3.4",
+        "@next/swc-win32-arm64-msvc": "16.3.4",
+        "@next/swc-win32-x64-msvc": "16.3.4",
+        "sharp": "^0.35.4"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.1.0",
+        "@playwright/test": "^1.51.1",
+        "babel-plugin-react-compiler": "*",
+        "react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0",
+        "react-dom": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0",
+        "sass": "^1.3.0"
+      },
+      "peerDependenciesMeta": {
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@playwright/test": {
+          "optional": true
+        },
+        "babel-plugin-react-compiler": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "license": "ISC"
+    },
+    "node_modules/postcss": {
+      "version": "8.5.23",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.23.tgz",
+      "integrity": "sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.16",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/react": {
+      "version": "19.2.8",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.8.tgz",
+      "integrity": "sha512-PWaYA1L/q9u2u7xYQi+Y3L3Yfnie7XyLeaJICV1MGD6LprsBxcAqGjYyr0eY3p+QdsA+x/Irkt4Qif8D63+Sbw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "19.2.8",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.8.tgz",
+      "integrity": "sha512-rVprimfGBG3DR+Tq0IQG2DT5PxKth1WIGDmj5yPmlzr4YBe7uyE+Du4oVqTDXZSHGGGXRtTJEGSSePyQCMBglQ==",
+      "license": "MIT",
+      "dependencies": {
+        "scheduler": "^0.27.0"
+      },
+      "peerDependencies": {
+        "react": "^19.2.8"
+      }
+    },
+    "node_modules/scheduler": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
+      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
+      "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "license": "ISC",
+      "optional": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/sharp": {
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.35.4.tgz",
+      "integrity": "sha512-n++8XWcj+jCOr2IOl7h8LbKnGBDY4aPbmprMONBNFdn0ImXqpGVv5zliDs0V9HbmbCQLpbuo2ej9rAoOQTvMDA==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@img/colour": "^1.1.0",
+        "detect-libc": "^2.1.2",
+        "semver": "^7.8.5"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-darwin-arm64": "0.35.4",
+        "@img/sharp-darwin-x64": "0.35.4",
+        "@img/sharp-freebsd-wasm32": "0.35.4",
+        "@img/sharp-libvips-darwin-arm64": "1.3.3",
+        "@img/sharp-libvips-darwin-x64": "1.3.3",
+        "@img/sharp-libvips-linux-arm": "1.3.3",
+        "@img/sharp-libvips-linux-arm64": "1.3.3",
+        "@img/sharp-libvips-linux-ppc64": "1.3.3",
+        "@img/sharp-libvips-linux-riscv64": "1.3.3",
+        "@img/sharp-libvips-linux-s390x": "1.3.3",
+        "@img/sharp-libvips-linux-x64": "1.3.3",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.3.3",
+        "@img/sharp-libvips-linuxmusl-x64": "1.3.3",
+        "@img/sharp-linux-arm": "0.35.4",
+        "@img/sharp-linux-arm64": "0.35.4",
+        "@img/sharp-linux-ppc64": "0.35.4",
+        "@img/sharp-linux-riscv64": "0.35.4",
+        "@img/sharp-linux-s390x": "0.35.4",
+        "@img/sharp-linux-x64": "0.35.4",
+        "@img/sharp-linuxmusl-arm64": "0.35.4",
+        "@img/sharp-linuxmusl-x64": "0.35.4",
+        "@img/sharp-webcontainers-wasm32": "0.35.4",
+        "@img/sharp-win32-arm64": "0.35.4",
+        "@img/sharp-win32-ia32": "0.35.4",
+        "@img/sharp-win32-x64": "0.35.4"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/styled-jsx": {
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.1.6.tgz",
+      "integrity": "sha512-qSVyDTeMotdvQYoHWLNGwRFJHC+i+ZvdBRYosOFgC+Wg1vx4frN2/RG/NA7SYqqvKNLf39P2LSRA2pu6n0XYZA==",
+      "license": "MIT",
+      "dependencies": {
+        "client-only": "0.0.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "peerDependencies": {
+        "react": ">= 16.8.0 || 17.x.x || ^18.0.0-0 || ^19.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "@babel/core": {
+          "optional": true
+        },
+        "babel-plugin-macros": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    }
+  }
+}

--- a/fixtures/next-consumer/package.json
+++ b/fixtures/next-consumer/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "stars-next-consumer-fixture",
+  "version": "0.0.0",
+  "private": true,
+  "scripts": {
+    "build": "next build"
+  },
+  "dependencies": {
+    "next": "16.3.4",
+    "react": "19.2.8",
+    "react-dom": "19.2.8"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "test:watch": "vitest",
     "test:e2e": "playwright test",
     "test:consumer": "node scripts/verify-consumer.mjs",
+    "test:next": "node scripts/verify-next.mjs",
     "coverage": "vitest run --coverage",
     "verify:package": "node scripts/verify-package.mjs",
     "verify:release": "node scripts/verify-release-notes.mjs",

--- a/scripts/ci-install.mjs
+++ b/scripts/ci-install.mjs
@@ -1,0 +1,20 @@
+import { spawnSync } from 'node:child_process';
+import { appendFileSync } from 'node:fs';
+import { performance } from 'node:perf_hooks';
+
+const start = performance.now();
+// Preserve audit and lifecycle scripts; prefer cached tarballs when available.
+const result = spawnSync('npm', ['ci', '--prefer-offline', '--no-fund'], {
+  stdio: 'inherit',
+});
+const seconds = ((performance.now() - start) / 1000).toFixed(1);
+const status = result.status ?? 1;
+const summary = `npm ci --prefer-offline: ${seconds}s (exit ${status})`;
+console.log(summary);
+if (process.env.GITHUB_STEP_SUMMARY)
+  appendFileSync(
+    process.env.GITHUB_STEP_SUMMARY,
+    `### Dependency installation\n\n${summary}\n`,
+  );
+if (result.error) console.error(result.error.message);
+process.exitCode = status;

--- a/scripts/verify-next.mjs
+++ b/scripts/verify-next.mjs
@@ -1,0 +1,151 @@
+import assert from 'node:assert/strict';
+import { spawn, spawnSync } from 'node:child_process';
+import { once } from 'node:events';
+import { cp, mkdtemp, rm } from 'node:fs/promises';
+import { createServer } from 'node:net';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { setTimeout as delay } from 'node:timers/promises';
+import { setTimeout, clearTimeout } from 'node:timers';
+import { fileURLToPath } from 'node:url';
+import { chromium, expect } from '@playwright/test';
+
+const root = fileURLToPath(new URL('../', import.meta.url));
+const directory = await mkdtemp(join(tmpdir(), 'stars-next-consumer-'));
+const app = join(directory, 'app');
+const env = { ...process.env, NEXT_TELEMETRY_DISABLED: '1' };
+let server;
+let browser;
+let serverOutput = '';
+
+const run = (command, args, cwd = app) => {
+  const started = Date.now();
+  const result = spawnSync(command, args, {
+    cwd,
+    env,
+    encoding: 'utf8',
+    timeout: 600_000,
+    maxBuffer: 10 * 1024 * 1024,
+  });
+  assert.equal(
+    result.status,
+    0,
+    `${command} ${args.join(' ')} failed: ${result.error ?? ''}\n${result.stdout}\n${result.stderr}`,
+  );
+  console.log(
+    `${command} ${args[0]} completed in ${((Date.now() - started) / 1000).toFixed(1)}s`,
+  );
+  return result.stdout;
+};
+
+try {
+  console.log(
+    'Packing the library and preparing an isolated Next.js consumer.',
+  );
+  const output = run(
+    'npm',
+    ['pack', '--json', '--pack-destination', directory],
+    root,
+  );
+  const [{ filename }] = JSON.parse(
+    output.slice(output.lastIndexOf('\n[') + 1),
+  );
+  await cp(join(root, 'fixtures/next-consumer'), app, { recursive: true });
+  run('npm', ['ci', '--prefer-offline', '--no-fund']);
+  run('npm', [
+    'install',
+    '--no-save',
+    '--package-lock=false',
+    '--no-fund',
+    join(directory, filename),
+  ]);
+  console.log(
+    'Building Next.js in production mode with the installed tarball.',
+  );
+  console.log(run('npm', ['run', 'build']));
+
+  const reservation = createServer();
+  reservation.listen(0, '127.0.0.1');
+  await once(reservation, 'listening');
+  const port = reservation.address().port;
+  await new Promise((resolve, reject) =>
+    reservation.close((error) => (error ? reject(error) : resolve())),
+  );
+  server = spawn(
+    process.execPath,
+    [
+      join(app, 'node_modules/next/dist/bin/next'),
+      'start',
+      '--hostname',
+      '127.0.0.1',
+      '--port',
+      String(port),
+    ],
+    { cwd: app, env, stdio: ['ignore', 'pipe', 'pipe'] },
+  );
+  server.stdout.on('data', (data) => {
+    serverOutput += data;
+  });
+  server.stderr.on('data', (data) => {
+    serverOutput += data;
+  });
+  const url = `http://127.0.0.1:${port}`;
+  let html;
+  for (let attempt = 0; attempt < 60; attempt++) {
+    assert.equal(server.exitCode, null, serverOutput);
+    try {
+      const response = await fetch(url, { signal: AbortSignal.timeout(1_000) });
+      if (response.ok) {
+        html = await response.text();
+        break;
+      }
+    } catch {
+      /* Wait for the production server to listen. */
+    }
+    await delay(500);
+  }
+  assert.ok(html, `Next.js did not become ready: ${serverOutput}`);
+  assert.match(html, /aria-label="Average rating"/);
+  assert.match(html, /aria-valuenow="4.3"/);
+
+  browser = await chromium.launch();
+  const page = await browser.newPage();
+  const errors = [];
+  page.on('pageerror', (error) => errors.push(error.message));
+  page.on('console', (message) => {
+    if (message.type() === 'error') errors.push(message.text());
+  });
+  await page.goto(url);
+  await expect(
+    page.getByRole('slider', { name: 'Average rating' }),
+  ).toHaveAttribute('aria-readonly', 'true');
+  const rating = page.getByRole('slider', { name: 'Your rating' });
+  await rating.focus();
+  await rating.press('ArrowRight');
+  await rating.press('Enter');
+  await expect(page.getByTestId('rating-value')).toHaveText('4');
+  await page.getByRole('button', { name: 'Restore initial rating' }).click();
+  await expect(rating).toHaveAttribute('aria-valuenow', '3.5');
+  await expect(page.getByTestId('rating-value')).toHaveText('3.5');
+  await page.getByRole('button', { name: 'Clear rating' }).click();
+  await expect(rating).toHaveAttribute('aria-valuenow', '0');
+  await expect(page.getByTestId('rating-value')).toHaveText('0');
+  assert.deepEqual(
+    errors,
+    [],
+    'Next.js consumer reported runtime or hydration errors',
+  );
+  console.log(
+    'Installed Next.js consumer passed: server boundary, SSR, hydration, keyboard and clearing.',
+  );
+} finally {
+  await browser?.close();
+  if (server && server.exitCode === null) {
+    const exited = once(server, 'exit');
+    server.kill('SIGTERM');
+    const timer = setTimeout(() => server.kill('SIGKILL'), 5_000);
+    await exited;
+    clearTimeout(timer);
+  }
+  await rm(directory, { recursive: true, force: true });
+}

--- a/src/__tests__/recipes.test.tsx
+++ b/src/__tests__/recipes.test.tsx
@@ -1,0 +1,79 @@
+import { useId, useRef, useState } from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import ReactStarsRating from '../lib';
+
+function RequiredRatingRecipe() {
+  const [rating, setRating] = useState(0);
+  const [error, setError] = useState(false);
+  const [submitted, setSubmitted] = useState<number | null>(null);
+  const ratingRef = useRef<HTMLSpanElement>(null);
+  const errorId = useId();
+  return (
+    <form
+      onSubmit={(event) => {
+        event.preventDefault();
+        const invalid = rating === 0;
+        setError(invalid);
+        if (invalid) ratingRef.current?.focus();
+        else setSubmitted(rating);
+      }}
+    >
+      <ReactStarsRating
+        ref={ratingRef}
+        name="rating"
+        value={rating}
+        onChange={(value) => {
+          setRating(value);
+          setError(false);
+        }}
+        ariaLabel="Your rating (required)"
+        aria-invalid={error || undefined}
+        aria-describedby={error ? errorId : undefined}
+      />
+      {error && (
+        <p id={errorId} role="alert">
+          Choose a rating before submitting.
+        </p>
+      )}
+      <button type="submit">Submit</button>
+      <button type="button" onClick={() => setRating(0)}>
+        Clear rating
+      </button>
+      <output data-testid="submitted">{submitted}</output>
+    </form>
+  );
+}
+
+test('required-rating recipe focuses, describes and clears its validation error', async () => {
+  const user = userEvent.setup();
+  render(<RequiredRatingRecipe />);
+  await user.click(screen.getByRole('button', { name: 'Submit' }));
+  const rating = screen.getByRole('slider');
+  expect(rating).toHaveFocus();
+  expect(rating).toHaveAttribute('aria-invalid', 'true');
+  expect(rating).toHaveAccessibleDescription(
+    'Choose a rating before submitting.',
+  );
+  expect(screen.getByTestId('submitted')).toBeEmptyDOMElement();
+  await user.keyboard('{ArrowRight}{Enter}');
+  expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+  expect(rating).not.toHaveAttribute('aria-invalid');
+  await user.click(screen.getByRole('button', { name: 'Submit' }));
+  expect(screen.getByTestId('submitted')).toHaveTextContent('0.5');
+  await user.click(screen.getByRole('button', { name: 'Clear rating' }));
+  expect(rating).toHaveAttribute('aria-valuenow', '0');
+  await user.click(screen.getByRole('button', { name: 'Submit' }));
+  expect(screen.getByRole('alert')).toBeVisible();
+});
+
+test('average-rating recipe preserves fractional values without editing', async () => {
+  const user = userEvent.setup();
+  render(<ReactStarsRating value={4.3} readOnly ariaLabel="Average rating" />);
+  const rating = screen.getByRole('slider', { name: 'Average rating' });
+  expect(rating).toHaveAttribute('aria-valuenow', '4.3');
+  expect(rating).toHaveAttribute('aria-readonly', 'true');
+  await user.click(rating);
+  await user.keyboard('{ArrowRight}');
+  expect(rating).toHaveAttribute('aria-valuenow', '4.3');
+});

--- a/src/lib/index.tsx
+++ b/src/lib/index.tsx
@@ -265,6 +265,15 @@ const ReactStarsRating = forwardRef<HTMLSpanElement, ReactStarsRatingProps>(
     const [isFocusVisible, setIsFocusVisible] = useState(false);
     const containerRef = useRef<HTMLSpanElement>(null);
     useImperativeHandle(forwardedRef, () => containerRef.current!, []);
+    // Synchronize the preview's source, not just its rendered value. Otherwise
+    // an A -> B -> A controlled update can resurrect the old preview for A.
+    if (displayState.sourceValue !== committedValue) {
+      setDisplayState({
+        sourceValue: committedValue,
+        displayValue: committedValue,
+      });
+      setHoverValue(null);
+    }
     const displayValue =
       displayState.sourceValue === committedValue
         ? displayState.displayValue


### PR DESCRIPTION
## Summary

- Fix a controlled A → B → A update resurrecting a stale preview, discovered by the new clear-rating recipe regression.
- Correct the README controlled example and add clear, fractional average, validation and Next.js recipes.
- Add a locked isolated Next.js 16.3.4 App Router consumer that installs the tarball, builds for production and checks server rendering, hydration, keyboard updates, restoring the initial value and clearing.
- Keep Next.js outside library dependencies; group its fixture updates in Dependabot.
- Add npm install timing summaries and prefer cached tarballs while retaining audit and lifecycle scripts; use a separate browser cache key including the fixture lockfile.
- Add a physical-device VoiceOver/TalkBack checklist. These manual checks have NOT been performed and no screen-reader certification is claimed.

## Validation

- 88 unit tests passed; coverage 100% statements/functions/lines and 97.75% branches.
- 99 browser tests passed; 6 intentional platform skips.
- Final clean-install rerun passed: Next.js production consumer, original-value restoration, clearing and isolated React 18/19 consumers. Full CI must pass before merge.
- Formatting, lint, lint regressions, typecheck, package/type validation, release-note verification and demo/Storybook builds passed.
- Bundle limits unchanged and passing: approximately 2.93 kB ESM, 2.98 kB CJS, 3.05 kB UMD gzip.
- Local timed clean install passed in 65s; compare several CI runs before claiming an improvement.

## Release

Dependabot #144 was merged first; no other bot PRs were open. This is the final planned patch batch before waiting for user feedback. Merge only after checks pass, then verify automated publication and provenance.